### PR TITLE
Change FerrisEpoch

### DIFF
--- a/lib/Constants.ts
+++ b/lib/Constants.ts
@@ -238,4 +238,4 @@ export enum WebSocketStatus {
 	IDENTIFYING = 5,
 }
 
-export const FERRIS_EPOCH = 1_577_836_800_000
+export const FERRIS_EPOCH = 1_641_016_800_000


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**

This PR changes the Ferris Epoch to 1641016800000ms after unix Epoch (1/1/2022 00:00:00.000000 -0600).

This will be merged on 12/31/2021 at 2345.

Library Maintainers, please test and approve this before the merge date. If there is a problem please LET ME KNOW ASAP.

**Context:**

- This PR **only** includes non-code changes, like changes to documentation, README, etc.


<!--
Please move lines that apply to you out of the comment:

-->

